### PR TITLE
Use versioned types

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/admission_test.go
@@ -152,15 +152,15 @@ func (f *fakeCompiler) HasSynced() bool {
 
 // Matches says whether this policy definition matches the provided admission
 // resource request
-func (f *fakeCompiler) DefinitionMatches(a admission.Attributes, o admission.ObjectInterfaces, definition *v1alpha1.ValidatingAdmissionPolicy) (bool, error) {
+func (f *fakeCompiler) DefinitionMatches(a admission.Attributes, o admission.ObjectInterfaces, definition *v1alpha1.ValidatingAdmissionPolicy) (bool, schema.GroupVersionKind, error) {
 	namespace, name := definition.Namespace, definition.Name
 	key := namespace + "/" + name
 	if fun, ok := f.DefinitionMatchFuncs[key]; ok {
-		return fun(definition, a), nil
+		return fun(definition, a), schema.GroupVersionKind{}, nil
 	}
 
 	// Default is match everything
-	return f.DefaultMatch, nil
+	return f.DefaultMatch, schema.GroupVersionKind{}, nil
 }
 
 // Matches says whether this policy definition matches the provided admission
@@ -506,7 +506,7 @@ func TestBasicPolicyDefinitionFailure(t *testing.T) {
 type testValidator struct {
 }
 
-func (v testValidator) Validate(a admission.Attributes, o admission.ObjectInterfaces, params runtime.Object) ([]policyDecision, error) {
+func (v testValidator) Validate(a admission.Attributes, o admission.ObjectInterfaces, params runtime.Object, matchKind schema.GroupVersionKind) ([]policyDecision, error) {
 	// Policy always denies
 	return []policyDecision{
 		{
@@ -693,7 +693,7 @@ func TestReconfigureBinding(t *testing.T) {
 		&admission.RuntimeObjectInterfaces{},
 	)
 
-	require.ErrorContains(t, err, `failed to configure policy: replicas-test2.example.com not found`)
+	require.ErrorContains(t, err, `failed to configure binding: replicas-test2.example.com not found`)
 	require.Equal(t, 1, numCompiles, "expect compile is not called when there is configuration error")
 	//require.Len(t, passedParams, 1, "expect evaluator was not called when there is configuration error")
 
@@ -898,7 +898,7 @@ func TestInvalidParamSourceInstanceName(t *testing.T) {
 	// expect the specific error to be that the param was not found, not that CRD
 	// is not existing
 	require.ErrorContains(t, err,
-		`failed to configure policy: replicas-test.example.com not found`)
+		`failed to configure binding: replicas-test.example.com not found`)
 	require.Len(t, passedParams, 0)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/controller.go
@@ -209,10 +209,16 @@ func (c *celAdmissionController) Validate(
 			}
 			return
 		case v1alpha1.Fail:
+			var message string
+			if binding == nil {
+				message = fmt.Errorf("failed to configure policy: %w", err).Error()
+			} else {
+				message = fmt.Errorf("failed to configure binding: %w", err).Error()
+			}
 			deniedDecisions = append(deniedDecisions, policyDecisionWithMetadata{
 				policyDecision: policyDecision{
 					kind:    deny,
-					message: fmt.Errorf("failed to configure policy: %w", err).Error(),
+					message: message,
 				},
 				definition: definition,
 				binding:    binding,
@@ -263,7 +269,7 @@ func (c *celAdmissionController) Validate(
 				paramRef := binding.Spec.ParamRef
 				if paramRef == nil {
 					// return error if ValidatingAdmissionPolicyBinding is mis-configured
-					return fmt.Errorf("ValidatingAdmissionPolicyBinding '%s' requires to set paramRef since policyName refers to a ValidatingAdmissionPolicy '%s' containing a paramKind: `%v`",
+					return fmt.Errorf("ValidatingAdmissionPolicyBinding '%s' requires paramRef since policyName refers to a ValidatingAdmissionPolicy '%s' with paramKind: `%v`",
 						binding.Name, definition.Name, paramKind.String())
 				}
 
@@ -300,8 +306,8 @@ func (c *celAdmissionController) Validate(
 				paramRef := binding.Spec.ParamRef
 				if paramRef != nil {
 					// return error if ValidatingAdmissionPolicyBinding is mis-configured
-					return fmt.Errorf("paramRef '%s' should be set in ValidatingAdmissionPolicyBinding '%s' since policyName refers to a ValidatingAdmissionPolicy '%s' does not contain a paramKind",
-						paramRef.String(), binding.Name, definition.Name)
+					return fmt.Errorf("ValidatingAdmissionPolicyBinding '%s' is not allowed to set paramRef to '%s' since policyName refers to a ValidatingAdmissionPolicy '%s' which has no paramKind",
+						binding.Name, paramRef.String(), definition.Name)
 				}
 			}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/controller.go
@@ -229,7 +229,7 @@ func (c *celAdmissionController) Validate(
 	}
 	for definitionNamespacedName, definitionInfo := range c.definitionInfo {
 		definition := definitionInfo.lastReconciledValue
-		matches, err := c.validatorCompiler.DefinitionMatches(a, o, definition)
+		matches, matchKind, err := c.validatorCompiler.DefinitionMatches(a, o, definition)
 		if err != nil {
 			return err
 		}
@@ -317,7 +317,7 @@ func (c *celAdmissionController) Validate(
 				c.bindingInfos[namespacedBindingName] = bindingInfo
 			}
 
-			decisions, err := bindingInfo.validator.Validate(a, o, param)
+			decisions, err := bindingInfo.validator.Validate(a, o, param, matchKind)
 			if err != nil {
 				// runtime error. Apply failure policy
 				wrappedError := fmt.Errorf("failed to evaluate CEL expression: %w", err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/interface.go
@@ -19,12 +19,15 @@ package cel
 import (
 	"k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 )
 
 // Validator defines the func used to validate the cel expressions
+// matchKind provides the GroupVersionKind that the object should be
+// validated by CEL expressions as.
 type Validator interface {
-	Validate(a admission.Attributes, o admission.ObjectInterfaces, params runtime.Object) ([]policyDecision, error)
+	Validate(a admission.Attributes, o admission.ObjectInterfaces, versionedParams runtime.Object, matchKind schema.GroupVersionKind) ([]policyDecision, error)
 }
 
 // ValidatorCompiler is Dependency Injected into the PolicyDefinition's `Compile`
@@ -32,7 +35,7 @@ type Validator interface {
 type ValidatorCompiler interface {
 	// Matches says whether this policy definition matches the provided admission
 	// resource request
-	DefinitionMatches(a admission.Attributes, o admission.ObjectInterfaces, definition *v1alpha1.ValidatingAdmissionPolicy) (bool, error)
+	DefinitionMatches(a admission.Attributes, o admission.ObjectInterfaces, definition *v1alpha1.ValidatingAdmissionPolicy) (bool, schema.GroupVersionKind, error)
 
 	// Matches says whether this policy definition matches the provided admission
 	// resource request

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/matching/matching.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/matching/matching.go
@@ -100,6 +100,7 @@ func (m *Matcher) Matches(attr admission.Attributes, o admission.ObjectInterface
 	return true, nil
 }
 
+// TODO: for equivalent matching, this needs to return what GVk was matched
 func matchesResourceRules(namedRules []v1alpha1.NamedRuleWithOperations, matchPolicy *v1alpha1.MatchPolicyType, attr admission.Attributes, o admission.ObjectInterfaces) bool {
 	for _, namedRule := range namedRules {
 		rule := v1.RuleWithOperations(namedRule.RuleWithOperations)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/matching/matching_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/matching/matching_test.go
@@ -90,8 +90,9 @@ func TestMatcher(t *testing.T) {
 		criteria *v1alpha1.MatchResources
 		attrs    admission.Attributes
 
-		expectMatches bool
-		expectErr     string
+		expectMatches   bool
+		expectMatchKind *schema.GroupVersionKind
+		expectErr       string
 
 		isBinding bool
 	}{
@@ -112,8 +113,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"apps", "v1", "Deployment"},
 		},
 		{
 			name: "specific rules, prefer exact match",
@@ -136,8 +138,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"apps", "v1", "Deployment"},
 		},
 		{
 			name: "specific rules, match miss",
@@ -195,8 +198,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1beta1"}, Resources: []string{"deployments"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"extensions", "v1beta1", "Deployment"},
 		},
 		{
 			name: "specific rules, equivalent match, prefer apps",
@@ -215,8 +219,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"extensions"}, APIVersions: []string{"v1beta1"}, Resources: []string{"deployments"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"apps", "v1", "Deployment"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"apps", "v1beta1", "Deployment"},
 		},
 
 		{
@@ -240,8 +245,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments", "deployments/scale"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"autoscaling", "v1", "Scale"},
 		},
 		{
 			name: "specific rules, subresource match miss",
@@ -299,8 +305,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1beta1"}, Resources: []string{"deployments", "deployments/scale"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"extensions", "v1beta1", "Scale"},
 		},
 		{
 			name: "specific rules, subresource equivalent match, prefer apps",
@@ -319,8 +326,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"extensions"}, APIVersions: []string{"v1beta1"}, Resources: []string{"deployments", "deployments/scale"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"apps", "v1beta1", "Scale"},
 		},
 		{
 			name: "specific rules, prefer exact match and name match",
@@ -334,8 +342,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"autoscaling", "v1", "Scale"},
 		},
 		{
 			name: "specific rules, prefer exact match and name match miss",
@@ -365,8 +374,9 @@ func TestMatcher(t *testing.T) {
 						Rule:       v1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments", "deployments/scale"}, Scope: &allScopes},
 					},
 				}}},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"extensions", "v1beta1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"extensions", "v1beta1", "deployments"}, "scale", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"autoscaling", "v1", "Scale"},
 		},
 		{
 			name: "specific rules, subresource equivalent match, prefer extensions and name match miss",
@@ -402,8 +412,9 @@ func TestMatcher(t *testing.T) {
 					},
 				}},
 			},
-			attrs:         admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
-			expectMatches: true,
+			attrs:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{"autoscaling", "v1", "Scale"}, "ns", "name", schema.GroupVersionResource{"apps", "v1", "deployments"}, "", admission.Create, &metav1.CreateOptions{}, false, nil),
+			expectMatches:   true,
+			expectMatchKind: &schema.GroupVersionKind{"autoscaling", "v1", "Scale"},
 		},
 		{
 			name: "exclude resource miss on match",
@@ -477,7 +488,7 @@ func TestMatcher(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			matches, err := a.Matches(testcase.attrs, interfaces, &fakeCriteria{matchResources: *testcase.criteria}, testcase.isBinding)
+			matches, matchKind, err := a.Matches(testcase.attrs, interfaces, &fakeCriteria{matchResources: *testcase.criteria}, testcase.isBinding)
 			if err != nil {
 				if len(testcase.expectErr) == 0 {
 					t.Fatal(err)
@@ -488,6 +499,11 @@ func TestMatcher(t *testing.T) {
 				return
 			} else if len(testcase.expectErr) > 0 {
 				t.Fatalf("expected error %q, got no error", testcase.expectErr)
+			}
+			if testcase.expectMatchKind != nil {
+				if *testcase.expectMatchKind != matchKind {
+					t.Fatalf("expected matchKind %v, got %v", testcase.expectMatchKind, matchKind)
+				}
 			}
 
 			if matches != testcase.expectMatches {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/cel/matching"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 )
 
 var _ ValidatorCompiler = &CELValidatorCompiler{}
@@ -165,15 +166,20 @@ func policyDecisionKindForError(f v1alpha1.FailurePolicyType) policyDecisionKind
 // Each PolicyDecision will have a decision and a message.
 // policyDecision.message will be empty if the decision is allowed and no error met.
 func (v *CELValidator) Validate(a admission.Attributes, o admission.ObjectInterfaces, params runtime.Object) ([]policyDecision, error) {
+	// TODO: pass in the GVK found by MatchType: Equivalent matching and pass it to NewVerionsedAttributes.
 	// TODO: replace unstructured with ref.Val for CEL variables when native type support is available
 
 	decisions := make([]policyDecision, len(v.compilationResults))
 	var err error
-	oldObjectVal, err := objectToResolveVal(a.GetOldObject())
+	versionedAttr, err := generic.NewVersionedAttributes(a, a.GetKind(), o)
 	if err != nil {
 		return nil, err
 	}
-	objectVal, err := objectToResolveVal(a.GetObject())
+	oldObjectVal, err := objectToResolveVal(versionedAttr.VersionedOldObject)
+	if err != nil {
+		return nil, err
+	}
+	objectVal, err := objectToResolveVal(versionedAttr.VersionedObject)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +187,7 @@ func (v *CELValidator) Validate(a admission.Attributes, o admission.ObjectInterf
 	if err != nil {
 		return nil, err
 	}
-	request := createAdmissionRequest(a)
+	request := createAdmissionRequest(versionedAttr.Attributes)
 	requestVal, err := convertObjectToUnstructured(request)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package cel
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/require"
 
@@ -282,6 +283,18 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "valid syntax for metadata",
+			policy: getValidPolicy([]v1alpha1.Validation{
+				{
+					Expression: "object.metadata.name == 'endpoints1'",
+				},
+			}, nil, nil),
+			attributes: newValidAttribute(false),
+			policyDecisions: []policyDecision{
+				generatedDecision(admit, "", ""),
+			},
+		},
+		{
 			name: "valid syntax for oldObject",
 			policy: getValidPolicy([]v1alpha1.Validation{
 				{
@@ -528,6 +541,9 @@ func newValidAttribute(object runtime.Object, isDelete bool) admission.Attribute
 	if !isDelete {
 		if object == nil {
 			object = &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "endpoints1",
+				},
 				Subsets: []corev1.EndpointSubset{
 					{
 						Addresses: []corev1.EndpointAddress{{IP: "127.0.0.0"}},

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/validator_test.go
@@ -289,7 +289,7 @@ func TestValidate(t *testing.T) {
 					Expression: "object.metadata.name == 'endpoints1'",
 				},
 			}, nil, nil),
-			attributes: newValidAttribute(false),
+			attributes: newValidAttribute(nil, false),
 			policyDecisions: []policyDecision{
 				generatedDecision(admit, "", ""),
 			},
@@ -515,8 +515,7 @@ func TestValidate(t *testing.T) {
 			CompilationResults := validator.(*CELValidator).compilationResults
 			require.Equal(t, len(validations), len(CompilationResults))
 
-			// TODO: construct objectInterface for testing
-			policyResults, err := validator.Validate(tc.attributes, nil, tc.params)
+			policyResults, err := validator.Validate(tc.attributes, newObjectInterfacesForTest(), tc.params, tc.attributes.GetKind())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -534,6 +533,13 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newObjectInterfacesForTest returns an ObjectInterfaces appropriate for test cases in this file.
+func newObjectInterfacesForTest() admission.ObjectInterfaces {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	return admission.NewObjectInterfacesFromScheme(scheme)
 }
 
 func newValidAttribute(object runtime.Object, isDelete bool) admission.Attributes {


### PR DESCRIPTION
This provides versioned object and oldObject to CEL. The version is selected by the definitions matcher using equivalence rules. This closely mimics what webhooks do.  I've added test coverage to the matcher tests to demonstrate the matching behavior.