### PR TITLE
Simplify handling of field path appends

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -18,7 +18,6 @@ package cel
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"strings"
 	"time"
 
@@ -67,9 +66,7 @@ type CompilationResult struct {
 	// as used by cel.EstimateCost.
 	MessageExpressionMaxCost uint64
 	// NormalizedRuleFieldPath represents the relative fieldPath specified by user after normalization.
-	NormalizedRuleFieldPath *field.Path
-	// FieldPathError represents the error while validating fieldPath specified.
-	FieldPathError *apiservercel.Error
+	NormalizedRuleFieldPath string
 }
 
 // EnvLoader delegates the decision of which CEL environment to use for each expression.
@@ -252,12 +249,9 @@ func compileRule(s *schema.Structural, rule apiextensions.ValidationRule, envSet
 		compilationResult.MessageExpressionMaxCost = costEst.Max
 	}
 	if rule.FieldPath != "" {
-		fldPath := field.NewPath("")
-		validFieldPath, err := ValidFieldPath(rule.FieldPath, fldPath, s)
-		if err != nil {
-			compilationResult.FieldPathError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "failed formatting fieldPath: " + err.Error()}
-		} else {
-			compilationResult.NormalizedRuleFieldPath = validFieldPath
+		validFieldPath, err := ValidFieldPath(rule.FieldPath, nil, s)
+		if err == nil {
+			compilationResult.NormalizedRuleFieldPath = validFieldPath.String()
 		}
 	}
 	return

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -260,10 +260,8 @@ func (s *Validator) validateExpressions(ctx context.Context, fldPath *field.Path
 			continue
 		}
 		if evalResult != types.True {
-			if compiled.FieldPathError != nil {
-				klog.V(2).ErrorS(compiled.FieldPathError, "fieldPath check failed")
-			} else if len(rule.FieldPath) > 0 {
-				fldPath = compiled.NormalizedRuleFieldPath.SetRoot(fldPath)
+			if len(compiled.NormalizedRuleFieldPath) > 0 {
+				fldPath = fldPath.Child(compiled.NormalizedRuleFieldPath)
 			}
 			if compiled.MessageExpression != nil {
 				messageExpression, newRemainingBudget, msgErr := evalMessageExpression(ctx, compiled.MessageExpression, rule.MessageExpression, activation, remainingBudget)

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/path.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/path.go
@@ -69,17 +69,6 @@ func (p *Path) Root() *Path {
 	return p
 }
 
-// SetRoot returns a Path with root replaced.
-func (p *Path) SetRoot(root *Path) *Path {
-	if p == nil {
-		return root
-	}
-	if root == nil {
-		return p
-	}
-	return root.Child(p.name)
-}
-
 // Child creates a new Path that is a child of the method receiver.
 func (p *Path) Child(name string, moreNames ...string) *Path {
 	r := NewPath(name, moreNames...)


### PR DESCRIPTION
This isn't quite right, but it fixes the "." prefix problem. We can follow up on replacing the `.Child()` call with a proper append after the release (the string output will be the same).